### PR TITLE
Refactor CLI Preset Generation Error Handling

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -71,8 +71,17 @@ export async function startCli() {
     await runInteractiveMode();
     return;
   }
-  const result = generatePresets(config);
-  logGenerationSuccess(result);
+  try {
+    const result = generatePresets(config);
+    logGenerationSuccess(result);
+  } catch (error) {
+    console.error(
+      chalk.red(
+        'Error: ' + (error instanceof Error ? error.message : String(error)),
+      ),
+    );
+    process.exit(1);
+  }
 }
 
 const executionArg = process.argv[1];
@@ -637,7 +646,12 @@ async function runInteractiveMode() {
     generationSpinner.stop();
   } catch (error) {
     generationSpinner.fail('Failed to generate presets');
-    throw error;
+    console.error(
+      chalk.red(
+        'Error: ' + (error instanceof Error ? error.message : String(error)),
+      ),
+    );
+    process.exit(1);
   }
 
   logGenerationSuccess(result);

--- a/src/presetLibrary.ts
+++ b/src/presetLibrary.ts
@@ -168,13 +168,9 @@ export function loadPresetLibrary(
   }
 
   if (presetLibrary.presets.length === 0) {
-    console.error(
-      chalk.red(
-        `Error: No presets found with glob pattern: ${pattern}.h2p in ` +
-          presetLibrary.presetsFolder,
-      ),
+    throw new Error(
+      `No presets found with glob pattern: ${pattern}.h2p in ${presetLibrary.presetsFolder}`,
     );
-    process.exit(1);
   }
 
   // Search and load .uhe-fav files

--- a/src/randomizer.ts
+++ b/src/randomizer.ts
@@ -19,8 +19,7 @@ export function generateFullyRandomPresets(
   config: Config,
 ): PresetLibrary {
   if (presetLibrary.presets.length === 0) {
-    console.error(chalk.red('Error: No presets available for randomization.'));
-    process.exit(1);
+    throw new Error('No presets available for randomization.');
   }
 
   const newPresetLibrary: PresetLibrary = {
@@ -171,10 +170,7 @@ export function generateRandomizedPresets(
     for (const presetString of config.preset) {
       const basePreset = findBasePreset(presetLibrary, presetString);
       if (!basePreset) {
-        console.error(
-          chalk.red(`Error: No preset with name ${presetString} found!`),
-        );
-        process.exit(1);
+        throw new Error(`No preset with name ${presetString} found!`);
       }
 
       generateVariationsForPreset(
@@ -195,10 +191,7 @@ export function generateRandomizedPresets(
     // Handle single preset (existing behavior)
     const basePreset = findBasePreset(presetLibrary, config.preset);
     if (!basePreset) {
-      console.error(
-        chalk.red(`Error: No preset with name ${config.preset ?? ''} found!`),
-      );
-      process.exit(1);
+      throw new Error(`No preset with name ${config.preset ?? ''} found!`);
     }
 
     generateVariationsForPreset(
@@ -322,22 +315,16 @@ export function generateMergedPresets(
         return el.filePath.includes(presetTitle);
       });
       if (!mergePreset) {
-        console.error(
-          chalk.red(`Error: No preset with name "${presetTitle}" found!`),
-        );
-        process.exit(1);
+        throw new Error(`No preset with name "${presetTitle}" found!`);
       }
       mergePresets.push(mergePreset);
     }
   }
 
   if (mergePresets.length < 2) {
-    console.error(
-      chalk.red(
-        'Error: Merge presets only works when at least two presets have been chosen',
-      ),
+    throw new Error(
+      'Merge presets only works when at least two presets have been chosen',
     );
-    process.exit(1);
   }
 
   for (let i = 0; i < (config.amount ?? 8); i++) {


### PR DESCRIPTION
…xit()

Changed error handling approach:
- generatePresets and downstream helpers (in presetLibrary.ts and randomizer.ts) now throw errors instead of calling process.exit(1)
- CLI catches these errors and handles process.exit() appropriately
- Removed chalk.red console.error calls from business logic in favor of throwing plain Error objects

This improves testability and allows the library to be used in contexts other than CLI (e.g., as an imported module).

🤖 Generated with [Claude Code](https://claude.com/claude-code)