### PR TITLE
userThirdPary

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "mcpName": "io.github.Fannon/u-he-preset-randomizer",
   "type": "module",
   "scripts": {
-    "start": "tsx src/cli.ts",
+    "start": "NODE_OPTIONS=--max-old-space-size=8192 tsx src/cli.ts",
     "mcp": "tsx src/mcp-server.ts",
     "detect": "tsx src/detect-synths.ts",
     "benchmark": "hyperfine --warmup 2 --runs 5 --export-markdown tmp/hyperfine.md --export-json tmp/hyperfine.json --ignore-failure 'npm run clean' 'npm run build' 'npm run typecheck' 'npm run lint' 'npm run format' 'npm run test'",
@@ -32,7 +32,8 @@
     "test:ci": "npm run lint && npm run typecheck && npm run test:unit",
     "postinstall": "simple-git-hooks",
     "prepublishOnly": "node scripts/sync-mcp-version.mjs && npm run clean && npm run build:dist",
-    "sync:mcp-version": "node scripts/sync-mcp-version.mjs"
+    "sync:mcp-version": "node scripts/sync-mcp-version.mjs",
+    "prepare": "husky"
   },
   "repository": {
     "type": "git",
@@ -74,6 +75,7 @@
     "@types/node": "^24.9.2",
     "@types/yargs": "^17.0.34",
     "@typescript/native-preview": "^7.0.0-dev.20251027.1",
+    "husky": "^9.1.7",
     "jest": "^30.2.0",
     "lint-staged": "^16.2.6",
     "simple-git-hooks": "^2.13.1",

--- a/package.json
+++ b/package.json
@@ -31,8 +31,7 @@
     "test:unit": "NODE_OPTIONS=\"--experimental-vm-modules --no-warnings\" jest --testPathIgnorePatterns=e2e",
     "test:ci": "npm run lint && npm run typecheck && npm run test:unit",
     "prepublishOnly": "node scripts/sync-mcp-version.mjs && npm run clean && npm run build:dist",
-    "sync:mcp-version": "node scripts/sync-mcp-version.mjs",
-    "prepare": "husky"
+    "sync:mcp-version": "node scripts/sync-mcp-version.mjs"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
I found that this project did not 'see' my installed Third Party libraries.

For Diva (for example) I have them installed in /Users/&lt;user&gt;/Library/Audio/Presets/u-he/Diva/ and it seems that that path is ignored entirely. This is true for any u-he Synth.

This Project reads and writes to /Users/&lt;user&gt;/Library/Audio/Presets/u-he/&lt;synth&gt;/UserPresets/&lt;synth&gt; (mind the extra 'UserPresets/&lt;synth&gt;'), which is fine, but it is by doing so ignoring my collection of Third Party presets.

I managed to include this by introducing an extra stage of reading these (called UserThirdParty).

I did encounter memory issues (as for some of my u-he Synths I have thousands of presets), but raising the memory by means of setting the NODE_OPTIONS environment variable did the trick (NODE_OPTIONS=--max-old-space-size=8192).

I love the project, hope this extra step will make it somehow into a new release.