### PR TITLE
Add "Run in Smithery" badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # u-he-preset-randomizer
 
+[![Run in Smithery](https://smithery.ai/badge/skills/fannon)](https://smithery.ai/skills?ns=fannon&utm_source=github&utm_medium=badge)
+
+
 Generate [u-he](https://u-he.com/) synth presets through randomization and merging of your existing presets (genetics like).
 
 This tool can generate random presets in three different modes:


### PR DESCRIPTION
## Add skill discoverability badge

Your 1 Claude skill is already indexed on [Smithery](https://smithery.ai), a directory of Agent Skills and MCP servers. This badge links users directly to your skills.

### Badge Preview
[![Run in Smithery](https://smithery.ai/badge/skills/Fannon)](https://smithery.ai/skills?ns=Fannon&utm_source=github&utm_medium=badge)

### Why add this?
- Users browsing your repo can discover and install your skills with one click
- No additional setup required - your skills are already listed

---

This is optional. Feel free to close if you prefer not to add external badges.